### PR TITLE
Use the scripts without model-viewer as the exported ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ srcScanInformation | Exported cameras in xml file from Agisoft
 src3D | 3D model in gltf file format
 src2D | Path where all 2D images are located. Currently these must be in png format.
 loadMeasurement | If this attribute is set, the viewer will try to load measurement data from the file `measurement.json` located in the same path as the GLTF file. See section [Measurements](#Measurements)
+viewSettings | An object with additional settings to adjust the viewer. Currently, it may have a property `skyBoxImage` with an URL to the image to be used for the sky-box in the 3D viewer, and a method `async resolve2dFileURL(key: string)`, that resolves the identifier from the XML file to an URL of the 2D image.
 
 ## Measurements
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@ulb-darmstadt/photogrammetry-viewer",
   "version": "0.0.10",
   "type": "module",
-  "main": "dist/photogrammetry-viewer.js",
-  "module": "dist/photogrammetry-viewer.js",
+  "main": "dist/photogrammetry-without-modelviewer.js",
+  "module": "dist/photogrammetry-without-modelviewer.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/photogrammetry-viewer.js",
-      "require": "./dist/photogrammetry-viewer.js"
+      "import": "./dist/photogrammetry-viewer-without-modelviewer.js",
+      "require": "./dist/photogrammetry-without-modelviewer.js"
     }
   },
   "files": [


### PR DESCRIPTION
As I understand it, the inclusion of the model-viewer is needed for whoever includes the script from a CDN.
Correspondingly, they do not care what NPM considers to be the exports.
Conversely, people installing this package from NPM (such as myself) may prefer to install the `model-viewer` themselves.

That's why in this PR I suggest to keep doing what you introduced with the two distributed JavaScript files, but this time declare the one without the model-viewer as the exported one.